### PR TITLE
use utf-8 as default charset & ability to change it

### DIFF
--- a/foundation-support-email/src/main/java/io/soffa/foundation/support/email/adapters/SmtpEmailSender.java
+++ b/foundation-support-email/src/main/java/io/soffa/foundation/support/email/adapters/SmtpEmailSender.java
@@ -40,6 +40,8 @@ public class SmtpEmailSender implements EmailSender {
         email.setHostName(config.getHostname()); // ERROR
         email.setSmtpPort(config.getPort());
         email.setStartTLSEnabled(config.isTls());
+        email.setCharset(message.getCharset());
+
         if (config.hasCredentials()) {
             email.setAuthenticator(new DefaultAuthenticator(
                 config.getUsername(),

--- a/foundation-support-email/src/main/java/io/soffa/foundation/support/email/model/Email.java
+++ b/foundation-support-email/src/main/java/io/soffa/foundation/support/email/model/Email.java
@@ -25,6 +25,7 @@ public class Email {
     private String textMessage;
     private String htmlMessage;
     private List<Attachment> attachments;
+    private String charset = "UTF-8";
 
     public Email(String subjet, EmailAddress sender, List<EmailAddress> to, String textMessage, String htmlMessage) {
         this.subject = subjet;


### PR DESCRIPTION
This addresses an issue where emails containing French special characters were not displaying correctly.

By setting the charset to UTF-8 in the `SmtpEmailSender`, all emails now display correctly.

The changes include:

- Adding a `charset` field to the `Email` class with a default value of "UTF-8".
- Using the specified `charset` in the `SmtpEmailSender`.

This ensures consistent encoding for all emails.